### PR TITLE
use c++-10 for tigerlake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(wirehair)
 
 set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_COMPILER /usr/bin/g++-10)
 
 set(LIB_SOURCE_FILES
         wirehair.cpp


### PR DESCRIPTION
SSSE3を使っているため. tigerlakeでビルドできない. 単純にgccがtigerlakeの存在を知らないだけらしい. 
g++ version 10を使うことで解決.

```
cc1plus: error: bad value (‘tigerlake’) for ‘-march=’ switch
cc1plus: note: valid arguments to ‘-march=’ switch are: nocona core2 nehalem corei7 westmere sandybridge corei7-avx ivybridge core-avx-i haswell core-avx2 broadwell skylake skylake-avx512 cannonlake icelake-client icelake-server cascadelake bonnell atom silvermont slm goldmont goldmont-plus tremont knl knm x86-64 eden-x2 nano nano-1000 nano-2000 nano-3000 nano-x2 eden-x4 nano-x4 k8 k8-sse3 opteron opteron-sse3 athlon64 athlon64-sse3 athlon-fx amdfam10 barcelona bdver1 bdver2 bdver3 bdver4 znver1 znver2 btver1 btver2 native
```

TODO:

- [x] gitai_linux_setupにg++-10を追加
- [ ] ros_wirehairの参照commitを変更